### PR TITLE
WIP: feat/支持 Canvas Web 异步版本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: ['18', '19']
+        node_version: ['18']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/packages/f-my/examples/test/pages/index/index.axml
+++ b/packages/f-my/examples/test/pages/index/index.axml
@@ -1,3 +1,6 @@
 <view class="container">
+  <view>native</view>
   <f-canvas onRender="onRenderChart" data="{{data}}"></f-canvas>
+  <view>web</view>
+  <f-canvas-web onRender="onRenderChart" data="{{data}}"></f-canvas-web>
 </view>

--- a/packages/f-my/examples/test/pages/index/index.json
+++ b/packages/f-my/examples/test/pages/index/index.json
@@ -1,5 +1,6 @@
 {
   "usingComponents": {
-    "f-canvas": "@antv/f-my"
+    "f-canvas": "@antv/f-my",
+    "f-canvas-web": "@antv/f-my/lib/web"
   }
 }

--- a/packages/f-my/src/adapter.ts
+++ b/packages/f-my/src/adapter.ts
@@ -1,0 +1,421 @@
+type TCanvasLineJoin = 'bevel' | 'round' | 'miter';
+type TCanvasLineCap = 'butt' | 'round' | 'square';
+type TCanvasTextBaseLine = 'top' | 'hanging' | 'middle' | 'alphabetic' | 'ideographic' | 'bottom';
+type TCanvasTextAlign = 'left' | 'right' | 'center' | 'start' | 'end';
+type TCanvasPatternRepeat = 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat';
+type TCanvasGradient = any;
+type TCanvasPattern = any;
+type TCanvasImageSource = IMiniProgramCanvasContext_v1 | CanvasImageElement;
+
+interface IMiniProgramCanvasContextImageInfo {
+  id: string | number | -1;
+  width: number;
+  height: number;
+  url: string;
+}
+
+function preloadCanvasImage(url: string, callback: (data: IMiniProgramCanvasContextImageInfo) => void) {
+  (my as any).preloadCanvasImage({
+    urls: [url],
+    complete(res: any) {
+      if (res && res.loaded) {
+        const img = res.loaded[url];
+        if (img.url == url && img.id !== -1) {
+          callback(img);
+          return;
+        }
+      }
+      callback(null);
+    }
+  })
+}
+
+interface IMiniProgramCanvasContext_v1 {
+  set fillStyle(value: string | TCanvasGradient | null | TCanvasPattern);
+  set font(value: string);
+  get font(): string;
+  set fontSize(value: any);
+  set strokeStyle(value: string | TCanvasGradient | null | TCanvasPattern);
+  set globalAlpha(value: number);
+  set lineWidth(value: number);
+  set lineCap(value: TCanvasLineCap);
+  set lineJoin(value: TCanvasLineJoin);
+  set miterLimit(value: number);
+  set textBaseline(value: TCanvasTextBaseLine);
+  set lineDashOffset(value: number);
+  set textAlign(value: TCanvasTextAlign);
+  set globalCompositeOperation(value: string);
+
+  setFillStyle(color: string | TCanvasGradient | null | TCanvasPattern): void;
+  fillRect(x: number, y: number, width: number, height: number): void;
+  strokeRect(x: number, y: number, width: number, height: number): void;
+  beginPath(): void;
+  arc(x: number, y: number, radius: number, startDeg: number, endDeg: number, anticlockwise?: boolean): void;
+  fill(): void;
+  clip(): void;
+  rect(x: number, y: number, width: number, height: number): void;
+  stroke(): void;
+  scale(x: number, y: number): void;
+  rotate(angle: number): void;
+  translate(x: number, y: number): void;
+  save(): void;
+  restore(): void;
+  clearRect(x: number, y: number, width: number, height: number): void;
+  fillText(text: string, x: number, y: number, maxWidth?: number): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void;
+  transform(a: number, b: number, c: number, d: number, e: number, f: number): void;
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void;
+  closePath(): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
+  setLineDash(gaps: number[]): void;
+  strokeText(text: string, x: number, y: number, maxWidth?: number): void;
+  setStrokeStyle(color: string | TCanvasGradient | null | TCanvasPattern): void;
+  setGlobalAlpha(alpha: number): void;
+  setLineWidth(width: number): void;
+  setLineCap(lineCap: TCanvasLineCap): void;
+  setLineJoin(lineJoin: TCanvasLineJoin): void;
+  setMiterLimit(limit: number): void;
+  setTextBaseline(baseline: TCanvasTextBaseLine): void;
+  setLineDashOffset(offset: number): void;
+  setTextAlign(align: TCanvasTextAlign): void;
+  setGlobalCompositeOperation(op: string): void;
+  setShadow(offsetX?: number, offsetY?: number, blur?: number, color?: string): void;
+  setFontSize(size: number): void;
+  setFont(font: string): void;
+  createRadialGradient(x0: number, y0: number, r0: number, x1: number, y1: number, r1: number): TCanvasGradient;
+  createCircularGradient(x: number, y: number, r: number): TCanvasGradient;
+  createLinearGradient(x0: number, y0: number, x1: number, y1: number): TCanvasGradient;
+  drawImage(
+    imageOrContext: TCanvasImageSource,
+    sx: number,
+    sy: number,
+    sWidth?: number,
+    sHeight?: number,
+    dx?: number,
+    dy?: number,
+    dWidth?: number,
+    dHeight?: number
+  ): void;
+  draw(reserve?: boolean): void;
+  createPattern(image: TCanvasImageSource, repeat: TCanvasPatternRepeat): TCanvasPattern;
+}
+
+export function createCanvasAdapter(canvasContext: any) {
+  const element = new CanvasElement(canvasContext);
+  const context = new SimulatedCanvasContext(canvasContext);
+  context.canvas = element;
+
+  return {
+    element,
+    context,
+    // debugger for unimplemented property/method
+    // element: new Proxy(element, {
+    //   get(target, p, receiver) {
+    //     const descriptor = Object.getOwnPropertyDescriptor(target, p);
+    //     const descriptor2 = Object.getOwnPropertyDescriptor((target as any).__proto__, p);
+    //     if (!descriptor && !descriptor2) {
+    //       debugger;
+    //     }
+    //     return Reflect.get(target, p, receiver);
+    //   }
+    // }),
+    // context: new Proxy(context, {
+    //   get(target, p, receiver) {
+    //     const descriptor = Object.getOwnPropertyDescriptor(target, p);
+    //     const descriptor2 = Object.getOwnPropertyDescriptor((target as any).__proto__, p);
+    //     if (!descriptor && !descriptor2) {
+    //       debugger;
+    //     }
+    //     return Reflect.get(target, p, receiver);
+    //   }
+    // })
+  }
+}
+function bindDrawRunnable(fn: any, canvasContext: IMiniProgramCanvasContext_v1) {
+  return function (this: any, ...args: unknown[]) {
+    try {
+      fn.apply(this, arguments);
+    } catch(ex) {debugger
+      throw ex;
+    } finally {
+      canvasContext.draw(true);
+    }
+  }
+}
+class CanvasImageElement {
+  private _onload?: undefined | (() => void);
+  private _onerror?: undefined | (() => void);
+  private _invoked: boolean = false;
+  private _rawImgObj?: IMiniProgramCanvasContextImageInfo | {} = undefined;
+  public static toImageSource(imageOrContext: any): TCanvasImageSource | null {
+    let target = null;
+    if (imageOrContext instanceof CanvasImageElement) {
+      target = imageOrContext._rawImgObj;
+    } else if (typeof imageOrContext === 'string') {
+      target = imageOrContext;
+    }
+
+    return target;
+  }
+  constructor(public url: string, private _context: IMiniProgramCanvasContext_v1) {
+    preloadCanvasImage(url, (img) => {
+      this._rawImgObj = img || {};
+      this._complete(this._rawImgObj);
+    });
+  }
+  private _complete(img: Partial<IMiniProgramCanvasContextImageInfo>) {
+    if (!img || this._invoked) {
+      return;
+    }
+    if (img.url == this.url && img.id !== -1) {
+      if (this._onload) {
+        bindDrawRunnable(this._onload, this._context)();
+        this._invoked = true;
+      }
+    } else {
+      if (this._onerror) {
+        bindDrawRunnable(this._onerror, this._context)();
+        this._invoked = true;
+      }
+    }
+  }
+  set onload(fn: () => void) {
+    this._onload = fn;
+    this._complete(this._rawImgObj);
+  }
+  set onerror(fn: () => void) {
+    this._onerror = fn;
+    this._complete(this._rawImgObj);
+  }
+}
+
+class CanvasElement {
+  constructor(
+    private canvasContext: IMiniProgramCanvasContext_v1
+  ) {
+
+  }
+  createImage(url: string) {
+    return new CanvasImageElement(url, this.canvasContext);
+  }
+  requestAnimationFrame(fn: any) {
+    const frameFn = bindDrawRunnable(fn, this.canvasContext);
+    return setTimeout(function () {
+      frameFn(Date.now());
+    }, 16);
+  }
+  cancelAnimationFrame(tid: any) {
+    return clearTimeout(tid);
+  }
+}
+class SimulatedCanvasContext {
+  public canvas: CanvasElement;
+
+  constructor(
+    private ctx: IMiniProgramCanvasContext_v1
+  ) {
+    
+  }
+
+  private _fillStyle: string | TCanvasGradient | null | TCanvasPattern;
+  set fillStyle(value: string | TCanvasGradient | null | TCanvasPattern) { this._fillStyle = this.ctx.fillStyle = value; }
+  get fillStyle(): string | TCanvasGradient | null | TCanvasPattern { return this._fillStyle; }
+
+  // WontFIX: filter
+
+  set font(value: string) { this.ctx.font = value; }
+  get font(): string { return this.ctx.font; }
+  set fontSize(value: any) {
+    this.ctx.fontSize = value;
+  }
+
+  private _globalAlpha = 1;
+  set globalAlpha(value: number) { this._globalAlpha = this.ctx.globalAlpha = value; }
+  get globalAlpha() { return this._globalAlpha; }
+
+  private _globalCompositeOperation: string;
+  set globalCompositeOperation(value: string) { this._globalCompositeOperation = this.ctx.globalCompositeOperation = value; }
+  get globalCompositeOperation() { return this._globalCompositeOperation; }
+
+  // WontFIX: imageSmoothingEnabled
+
+  private _lineCap: TCanvasLineCap;
+  set lineCap(value: TCanvasLineCap) { this._lineCap = this.ctx.lineCap = value; }
+  get lineCap() { return this._lineCap; }
+
+  private _lineDashOffset: number;
+  set lineDashOffset(value: number) { this._lineDashOffset = this.ctx.lineDashOffset = value; }
+  get lineDashOffset() { return this._lineDashOffset; }
+
+  private _lineJoin: TCanvasLineJoin;
+  set lineJoin(value: TCanvasLineJoin) { this._lineJoin = this.ctx.lineJoin = value; }
+  get lineJoin() { return this._lineJoin; }
+
+  private _lineWidth: number;
+  set lineWidth(value: number) { this.ctx.lineWidth = value; }
+  get lineWidth() { return this._lineWidth; }
+
+  private _miterLimit: number;
+  set miterLimit(value: number) { this._miterLimit = this.ctx.miterLimit = value; }
+  get miterLimit() { return this._miterLimit; }
+
+  // WontFIX: shadowBlur
+  // WontFIX: shadowColor
+  // WontFIX: shadowOffsetX
+  // WontFIX: shadowOffsetY
+
+  private _strokeStyle: string | TCanvasGradient | null | TCanvasPattern;
+  set strokeStyle(value: string | TCanvasGradient | null | TCanvasPattern) { this._strokeStyle = this.ctx.strokeStyle = value; }
+  get strokeStyle() { return this._strokeStyle; }
+
+  private _textAlign: TCanvasTextAlign;
+  set textAlign(value: TCanvasTextAlign) { this._textAlign = this.ctx.textAlign = value; }
+  get textAlign() { return this._textAlign; }
+
+  private _textBaseline: TCanvasTextBaseLine;
+  set textBaseline(value: TCanvasTextBaseLine) { this._textBaseline = this.ctx.textBaseline = value; }
+  get textBaseline() { return this._textBaseline; }
+
+  public arc(x: number, y: number, radius: number, startDeg: number, endDeg: number, anticlockwise?: boolean): void {
+    if (anticlockwise === undefined) {
+      return this.ctx.arc(x, y, radius, startDeg, endDeg);
+    }
+    return this.ctx.arc(x, y, radius, startDeg, endDeg, anticlockwise);
+  }
+  public arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void {
+    return this.ctx.arcTo(x1, y1, x2, y2, radius);
+  }
+  public beginPath(): void {
+    return this.ctx.beginPath();
+  }
+  public bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void {
+    return this.ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
+  }
+  public clearRect(x: number, y: number, width: number, height: number): void {
+    return this.ctx.clearRect(x, y, width, height);
+  }
+  public clip(): void {
+    return this.ctx.clip();
+  }
+  public closePath(): void {
+    return this.ctx.closePath();
+  }
+  // WontFIX: createImageData
+  public createLinearGradient(x0: number, y0: number, x1: number, y1: number): TCanvasGradient {
+    return this.ctx.createLinearGradient(x0, y0, x1, y1);
+  }
+  public createPattern(image: TCanvasImageSource, repeat: TCanvasPatternRepeat): TCanvasPattern {
+    const target = CanvasImageElement.toImageSource(image);
+    return this.ctx.createPattern(target, repeat);
+  }
+  public createRadialGradient(x0: number, y0: number, r0: number, x1: number, y1: number, r1: number): TCanvasGradient {
+    return this.ctx.createRadialGradient(x0, y0, r0, x1, y1, r1);
+  }
+  // WontFIX: createPath2D
+  drawImage(
+    imageOrContext: TCanvasImageSource,
+    sx: number,
+    sy: number,
+    sWidth: number,
+    sHeight: number,
+    dx: number,
+    dy: number,
+    dWidth: number,
+    dHeight: number
+  ): void {
+    const target = CanvasImageElement.toImageSource(imageOrContext);
+    if (!target) {
+      return;
+    }
+    if (sWidth === undefined) {
+      this.ctx.drawImage(target, sx, sy);
+    } else if (dx === undefined) {
+      this.ctx.drawImage(target, sx, sy, sWidth, sHeight);
+    } else {
+      this.ctx.drawImage(target, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+    }
+  }
+  public ellipse(x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, anticlockwise?: boolean) {
+    this.save();
+    this.translate(x, y);
+    this.rotate(rotation);
+    this.scale(radiusX, radiusY);
+    this.arc(0, 0, 1, startAngle, endAngle, anticlockwise);
+    this.restore();
+  }
+  public fill(): void {
+    return this.ctx.fill();
+  }
+  public fillRect(x: number, y: number, width: number, height: number): void {
+    return this.ctx.fillRect(x, y, width, height);
+  }
+  public fillText(text: string, x: number, y: number, maxWidth?: number): void {
+    if (maxWidth === undefined) {
+      return this.ctx.fillText(text, x, y);
+    }
+    return this.ctx.fillText(text, x, y, maxWidth);
+  }
+  // WontFIX: getImageData
+  // WontFIX: getLineDash
+  // WontFIX: getTransform
+  // Only For Offscreen: isPointInPath
+  // WontFIX: isPointInStroke
+  public lineTo(x: number, y: number): void {
+    return this.ctx.lineTo(x, y);
+  }
+  // Only For Offscreen: measureText
+  public moveTo(x: number, y: number): void {
+    return this.ctx.moveTo(x, y);
+  }
+  // WontFIX: putImageData
+  public quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void {
+    return this.ctx.quadraticCurveTo(cpx, cpy, x, y);
+  }
+  public rect(x: number, y: number, width: number, height: number): void {
+    return this.ctx.rect(x, y, width, height);
+  }
+  public resetTransform() {
+    return this.setTransform(1, 0, 0, 1, 0, 0);
+  }
+  public restore(): void {
+    return this.ctx.restore();
+  }
+  public rotate(angle: number): void {
+    return this.ctx.rotate(angle);
+  }
+  // WontFIX: roundRect
+  public save(): void {
+    return this.ctx.save();
+  }
+  public scale(x: number, y: number): void {
+    return this.ctx.scale(x, y);
+  }
+  public setLineDash(gaps: number[]): void {
+    return this.ctx.setLineDash(gaps);
+  }
+  public setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    return this.ctx.setTransform(a, b, c, d, e, f);
+  }
+  public stroke(): void {
+    return this.ctx.stroke();
+  }
+  public strokeRect(x: number, y: number, width: number, height: number): void {
+    return this.ctx.fillRect(x, y, width, height);
+  }
+  public strokeText(text: string, x: number, y: number, maxWidth?: number): void {
+    if (maxWidth === undefined) {
+      this.ctx.strokeText(text, x, y);
+    }
+    return this.ctx.strokeText(text, x, y, maxWidth);
+  }
+  public transform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    return this.ctx.transform(a, b, c, d, e, f);
+  }
+  public translate(x: number, y: number): void {
+    return this.ctx.translate(x, y);
+  }
+
+}

--- a/packages/f-my/src/adapter.ts
+++ b/packages/f-my/src/adapter.ts
@@ -204,10 +204,13 @@ class CanvasElement {
     return new CanvasImageElement(url, this.canvasContext, this._addCallIdAction);
   }
   requestAnimationFrame(fn: any) {
-    const frameFn = bindDrawRunnable(fn, this.canvasContext, this._addCallIdAction);
-    return setTimeout(function () {
+    const frameFn = bindDrawRunnable(fn, this.canvasContext,this._addCallIdAction);
+    const offscreenCanvas = (my as any).createOffscreenCanvas
+      ? (my as any).createOffscreenCanvas()
+      : { requestAnimationFrame: () => {} };
+    return offscreenCanvas.requestAnimationFrame(() => {
       frameFn(Date.now());
-    }, 16);
+    });
   }
   cancelAnimationFrame(tid: any) {
     return clearTimeout(tid);

--- a/packages/f-my/src/adapter.ts
+++ b/packages/f-my/src/adapter.ts
@@ -139,9 +139,7 @@ export function createCanvasAdapter(canvasContext: any) {
 function bindDrawRunnable(fn: any, canvasContext: IMiniProgramCanvasContext_v1, addCallIdAction: () => void) {
   return function (this: any, ...args: unknown[]) {
     try {
-      fn.apply(this, arguments);
-    } catch(ex) {debugger
-      throw ex;
+      fn.apply(this, args);
     } finally {
       canvasContext.draw(true);
       addCallIdAction();
@@ -317,11 +315,11 @@ class SimulatedCanvasContext {
   public addCallIdActions(): void {
     const { linearGradient, radialGradient } = this._callIdCache;
     this._enableCacheCallId = false;
-    for (let item of linearGradient ) {
+    for (const item of linearGradient ) {
       const gradient = this.ctx.createLinearGradient(0, 0, 0, 0);
       Object.assign(gradient, item);
     }
-    for (let item of radialGradient ) {
+    for (const item of radialGradient ) {
       const gradient = this.ctx.createRadialGradient(0, 0, 0, 0, 0, 0);
       Object.assign(gradient, item);
     }

--- a/packages/f-my/src/web.acss
+++ b/packages/f-my/src/web.acss
@@ -1,0 +1,4 @@
+.f-canvas {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/f-my/src/web.axml
+++ b/packages/f-my/src/web.axml
@@ -1,0 +1,11 @@
+<canvas
+  a:if="{{id}}"
+  id="{{id}}"
+  class="f-canvas"
+  width="{{width}}"
+  height="{{height}}"
+  onTap="click"
+  onTouchStart="touchStart"
+  onTouchMove="touchMove"
+  onTouchEnd="touchEnd"
+/>

--- a/packages/f-my/src/web.json
+++ b/packages/f-my/src/web.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/packages/f-my/src/web.tsx
+++ b/packages/f-my/src/web.tsx
@@ -1,0 +1,191 @@
+import { Canvas } from '@antv/f-engine';
+import { createCanvasAdapter } from './adapter';
+
+function convertTouches(touches) {
+  if (!touches) return touches;
+  touches.forEach((touch) => {
+    touch.clientX = touch.x;
+    touch.clientY = touch.y;
+  });
+  return touches;
+}
+
+function dispatchEvent(el, event, type) {
+  if (!el || !event) return;
+  if (!event.preventDefault) {
+    event.preventDefault = function() {};
+  }
+  event.type = type;
+  event.target = el;
+  const { touches, changedTouches, detail } = event;
+  event.touches = convertTouches(touches);
+  event.changedTouches = convertTouches(changedTouches);
+  if (detail) {
+    event.clientX = detail.x;
+    event.clientY = detail.y;
+  }
+  el.dispatchEvent(event);
+}
+
+const getPixelRatio = () => my.getSystemInfoSync().pixelRatio;
+
+Component({
+  props: {
+    onRender: (_props) => {},
+    // width height 会作为元素兜底的宽高使用
+    width: null,
+    height: null,
+    onError: () => {},
+    onCanvasReady: () => {},
+    onCanvasRender: () => {},
+  },
+  /**
+   * 组件创建时触发
+   * 注意：
+   *    使用该生命周期，项目配置需启用："component2": true
+   */
+  onInit() {
+    this.setCanvasId();
+  },
+  didMount() {
+    // 为了兼容未配置 "component2": true 的情况
+    if (!this.data.id) {
+      this.setCanvasId();
+    }
+    this.onCanvasReady();
+  },
+  didUpdate() {
+    const { canvas, props } = this;
+    if (!canvas) return;
+    const { theme, px2hd } = props;
+    const children = props.onRender(props);
+    const updateProps = {
+      theme,
+      px2hd,
+      children,
+    };
+    canvas.update(updateProps).catch((error) => {
+      this.catchError(error);
+    });
+  },
+  didUnmount() {
+    const { canvas } = this;
+    if (!canvas) return;
+    canvas.destroy();
+  },
+  methods: {
+    setCanvasId() {
+      const pageId = (this.$page && this.$page.$id) || 0;
+      const id = `f-canvas-${pageId}-${this.$id}`;
+      this.setData({ id });
+    },
+    onCanvasReady() {
+      const { onCanvasReady } = this.props;
+      onCanvasReady && onCanvasReady();
+      const { id } = this.data;
+      const query = my.createSelectorQuery();
+      query
+        .select(`#${id}`)
+        .boundingClientRect()
+        .exec((res) => {
+
+          if (!res[0]) {
+            return;
+          }
+          const { width, height } = res[0] as {
+            width: number;
+            height: number;
+          };
+          const pixelRatio = Math.ceil(getPixelRatio());
+
+          // 高清解决方案
+          this.setData(
+            {
+              width: width * pixelRatio,
+              height: height * pixelRatio,
+            },
+            () => {
+              const {
+                element: canvas,
+                context
+              } = createCanvasAdapter(my.createCanvasContext(id));
+              try {
+                const fCanvas = this.createCanvas({
+                  width,
+                  height,
+                  pixelRatio,
+                  context,
+                  createImage: canvas.createImage.bind(canvas),
+                  requestAnimationFrame: canvas.requestAnimationFrame.bind(canvas),
+                  cancelAnimationFrame: canvas.cancelAnimationFrame.bind(canvas),
+                });
+                fCanvas.render().catch((error) => {debugger
+                  this.catchError(error);
+                });
+              } catch(ex) {
+                debugger
+              }
+            },
+          );
+      });
+    },
+
+    catchError(error) {
+      console.error('图表渲染失败: ', error);
+      const { onError } = this.props;
+      if (typeof onError === 'function') {
+        onError(error);
+      }
+      throw error;
+    },
+
+    createCanvas({
+      width,
+      height,
+      pixelRatio,
+      context,
+      createImage,
+      requestAnimationFrame,
+      cancelAnimationFrame,
+    }) {
+      if (!width || !height) {
+        return;
+      }
+      const { theme, px2hd, onCanvasRender } = this.props;
+      const children = this.props.onRender(this.props);
+      const canvas = new Canvas({
+        pixelRatio,
+        width,
+        height,
+        theme,
+        px2hd,
+        context,
+        children,
+        createImage,
+        requestAnimationFrame,
+        cancelAnimationFrame,
+        onRender: onCanvasRender,
+        // @ts-ignore
+        offscreenCanvas: my.createOffscreenCanvas ? my.createOffscreenCanvas() : null,
+        // useNativeClickEvent: false,
+        isTouchEvent: (e) => e.type.startsWith('touch'),
+        isMouseEvent: (e) => e.type.startsWith('mouse'),
+      });
+      this.canvas = canvas;
+      this.canvasEl = canvas.getCanvasEl();
+      return canvas;
+    },
+    click(e) {
+      dispatchEvent(this.canvasEl, e, 'click');
+    },
+    touchStart(e) {
+      dispatchEvent(this.canvasEl, e, 'touchstart');
+    },
+    touchMove(e) {
+      dispatchEvent(this.canvasEl, e, 'touchmove');
+    },
+    touchEnd(e) {
+      dispatchEvent(this.canvasEl, e, 'touchend');
+    },
+  },
+});

--- a/packages/f-my/src/web.tsx
+++ b/packages/f-my/src/web.tsx
@@ -88,7 +88,6 @@ Component({
         .select(`#${id}`)
         .boundingClientRect()
         .exec((res) => {
-
           if (!res[0]) {
             return;
           }
@@ -105,29 +104,22 @@ Component({
               height: height * pixelRatio,
             },
             () => {
-              const {
-                element: canvas,
-                context
-              } = createCanvasAdapter(my.createCanvasContext(id));
-              try {
-                const fCanvas = this.createCanvas({
-                  width,
-                  height,
-                  pixelRatio,
-                  context,
-                  createImage: canvas.createImage.bind(canvas),
-                  requestAnimationFrame: canvas.requestAnimationFrame.bind(canvas),
-                  cancelAnimationFrame: canvas.cancelAnimationFrame.bind(canvas),
-                });
-                fCanvas.render().catch((error) => {debugger
-                  this.catchError(error);
-                });
-              } catch(ex) {
-                debugger
-              }
+              const { element: canvas, context } = createCanvasAdapter(my.createCanvasContext(id));
+              const fCanvas = this.createCanvas({
+                width,
+                height,
+                pixelRatio,
+                context,
+                createImage: canvas.createImage.bind(canvas),
+                requestAnimationFrame: canvas.requestAnimationFrame.bind(canvas),
+                cancelAnimationFrame: canvas.cancelAnimationFrame.bind(canvas),
+              });
+              fCanvas.render().catch((error) => {
+                this.catchError(error);
+              });
             },
           );
-      });
+        });
     },
 
     catchError(error) {

--- a/packages/f-my/tsconfig.json
+++ b/packages/f-my/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2015", "dom"],
     "types": ["mini-types"]
   }
 }


### PR DESCRIPTION
在支付宝小程序中，可以使用最早期的 [小程序异步版本 Canvas](https://opendocs.alipay.com/mini/api/canvascontext) 「以下用 CanvasContext 来指代」来满足图形绘制需求（而不需要强依赖新版本的 Canvas 同层实现能力）

## 实现方案

原始依赖的 CanvasElement 和 getContext('2d') 「以下用 CanvasRenderingContext2D 来指代」 提供了与 W3C 完全一致的 API，但是降级版本的 CanvasContext 内部实现为异步指令批量发送模式，并且需要主动调用 `context.draw()` 来触发指令提交，因此 API 调用上有如下差异

### 模拟实现

- CanvasElement
  - createImage（API 对接到 my.preloadCanvasImage，提供 onload / onerror 回调）
  - requestAnimationFrame（API 对接到 setTimeout，并且在每次结束主动调用 `canvasContext.draw()` 来同步指令）
  - cancelAnimationFrame
- 模拟的 CanvasRenderingContext2D （API 对接到 CanvasContext）
  - 实际支持度见下表

### 注意事项

仅假设「Canvas 同层实现能力」不可用，而 「my.createOffscreenCanvas」仍然可用，因此涉及到 OffscreenCanvas 的调用均未处理

## API 支持度

### 未提供以下 API 支持

- filter
- imageSmoothingEnabled
- shadowBlur
- shadowColor
- shadowOffsetX
- shadowOffsetY
- createImageData
- createPath2D
- getImageData
- getLineDash
- getTransform
- isPointInPath（仅 OffscreenCanvas 使用，不受影响）
- isPointInStroke
- measureText（仅 OffscreenCanvas 使用，不受影响）
- putImageData
- roundRect

### 提供了以下 API 的兼容

#### 属性

> 注意，由于 CanvasContext 为异步指令批量发送模式，此处所有 get 属性均为模拟实现

- set fillStyle
- get fillStyle
- set font
- get font
- set fontSize
- set globalAlpha
- get globalAlpha
- set globalCompositeOperation
- get globalCompositeOperation
- set lineCap
- get lineCap
- set lineDashOffset
- get lineDashOffset
- set lineJoin
- get lineJoin
- set lineWidth
- get lineWidth
- set miterLimit
- get miterLimit
- set strokeStyle
- get strokeStyle
- set textAlign
- get textAlign
- set textBaseline
- get textBaseline

#### 方法

- arc(x: number, y: number, radius: number, startDeg: number, endDeg: number, anticlockwise?: boolean)
- arcTo(x1: number, y1: number, x2: number, y2: number, radius: number)
- beginPath()
- bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number)
- clearRect(x: number, y: number, width: number, height: number)
- clip()
- closePath()
- createLinearGradient(x0: number, y0: number, x1: number, y1: number)
- createPattern(image: TCanvasImageSource, repeat: TCanvasPatternRepeat)
- createRadialGradient(x0: number, y0: number, r0: number, x1: number, y1: number, r1: number)
- drawImage(image: TCanvasImageSource, sx: number, sy: number, sWidth?: number, sHeight?: number, dx?: number, dy?: number, dWidth?: number, dHeight?: number)
 - ellipse(x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, anticlockwise?: boolean)
- fill()
- fillRect(x: number, y: number, width: number, height: number)
- fillText(text: string, x: number, y: number, maxWidth?: number)
- lineTo(x: number, y: number)
- moveTo(x: number, y: number)
- quadraticCurveTo(cpx: number, cpy: number, x: number, y: number)
- rect(x: number, y: number, width: number, height: number)
- resetTransform()
- restore()
- rotate(angle: number)
- save()
- scale(x: number, y: number)
- setLineDash(gaps: number[])
- setTransform(a: number, b: number, c: number, d: number, e: number, f: number)
- stroke()
- strokeRect(x: number, y: number, width: number, height: number)
- strokeText(text: string, x: number, y: number, maxWidth?: number)
- transform(a: number, b: number, c: number, d: number, e: number, f: number)
- translate(x: number, y: number)